### PR TITLE
Image extraction test failures

### DIFF
--- a/src/main/java/hellofx/Gameplay.java
+++ b/src/main/java/hellofx/Gameplay.java
@@ -44,7 +44,8 @@ public class Gameplay {
     private H2Point startPressPosition;
     private long lastRender;
 
-    static long MILLIS_DELAY = 100L * 1000L * 1000L;
+    static long FPS = 5;
+    static long FPS_NANOS_DELAY = 1000L * 1000L * 1000L / FPS;
 
     public void setup() {
         setupRandomLevel();
@@ -93,8 +94,9 @@ public class Gameplay {
     }
 
     void onFrameUpdate(Long l) {
-
-        if (l - lastRender > MILLIS_DELAY) { // 10 FPS
+        // FIXME: computation is actually broken, and some several
+        // frames should be sometimes skipped.
+        if (l - lastRender > FPS_NANOS_DELAY) {
             lastRender = l;
             Game.nextFrame();
         }

--- a/src/main/java/hellofx/Gameplay.java
+++ b/src/main/java/hellofx/Gameplay.java
@@ -42,12 +42,15 @@ public class Gameplay {
     private Image heroesImg;
     private Image heroesImgSmooth;
     private H2Point startPressPosition;
+    private long lastRender;
+
+    static long MILLIS_DELAY = 100L * 1000L * 1000L;
 
     public void setup() {
         setupRandomLevel();
         playerList = new PlayerList(2);
         ctx.listen(EventNames.onFrame, (Long l) -> {
-            onFrameUpdate();
+            onFrameUpdate(l);
         });
         ctx.listen(EventNames.onMouse, (MouseEvent mEvent) -> {
 
@@ -89,8 +92,13 @@ public class Gameplay {
         }
     }
 
-    void onFrameUpdate() {
-        Game.nextFrame();
+    void onFrameUpdate(Long l) {
+
+        if (l - lastRender > MILLIS_DELAY) { // 10 FPS
+            lastRender = l;
+            Game.nextFrame();
+        }
+
         idx += 1;
         //gameArea.camera.left = (int) idx / 5;
         //gameArea.camera.top = (int) (idx / 1.3);
@@ -104,6 +112,5 @@ public class Gameplay {
         var rect = new H2Rect(0, 0, 3440 / gameArea.camera.tileSize + 2, 1440 / gameArea.camera.tileSize + 2);
 
         gameArea.Repaint(painter, LevelKind.LEVEL_ALL, rect, agg);
-
     }
 }

--- a/src/test/java/hellofx/fxheroes2/agg/SpriteExtractionTest.java
+++ b/src/test/java/hellofx/fxheroes2/agg/SpriteExtractionTest.java
@@ -3,16 +3,25 @@ package hellofx.fxheroes2.agg;
 import hellofx.fheroes2.agg.Agg;
 import hellofx.fheroes2.agg.Sprite;
 import hellofx.fheroes2.agg.icn.IcnKind;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-public class SpriteExtractionTest {
-    @Test
-    void testSpriteReading() {
-        Agg agg = Agg.Get();
-        agg.setup();
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+public class SpriteExtractionTest {
+    private static Agg agg;
+
+    @BeforeAll
+    public static void initTests() {
+        agg = Agg.Get();
+        agg.setup();
+    }
+    
+//    @Test
+    void testWriteSpritesToDisk() {
         for (int i = 0; i < IcnKind.LASTICN; i++) {
             int spritesPerIcon = agg.IcnSpriteCount(i);
             for (int j = 0; j < spritesPerIcon; j++) {
@@ -26,5 +35,40 @@ public class SpriteExtractionTest {
                 sprite.saveToFile(new File(fileName));
             }
         }
+    }
+
+    @Test
+    void testCreatureSizeShouldBeNormal() {
+        Sprite sprite = agg.GetICN(227, 38);
+        sprite = agg.GetICN(227, 39);
+
+        assertTrue(sprite.Width < 100,
+                String.format(
+                        "The icon width was supposed to be less than a 100 pixels but it was %d pixels",
+                        sprite.Width
+                ));
+        assertTrue(sprite.Height < 100,
+                String.format(
+                        "The icon height was supposed to be less than a 100 pixels but it was %d pixels",
+                        sprite.Height
+                ));
+    }
+
+    @Test
+    void testHeroSizeShouldBeNormal() {
+        Sprite sprite = agg.GetICN(106, 14);
+        sprite = agg.GetICN(106, 15);
+
+
+        assertTrue(sprite.Width < 100,
+                String.format(
+                        "The icon width was supposed to be less than a 100 pixels but it was %d pixels",
+                        sprite.Width
+                ));
+        assertTrue(sprite.Height < 100,
+                String.format(
+                        "The icon height was supposed to be less than a 100 pixels but it was %d pixels",
+                        sprite.Height
+                ));
     }
 }

--- a/src/test/java/hellofx/fxheroes2/agg/SpriteExtractionTest.java
+++ b/src/test/java/hellofx/fxheroes2/agg/SpriteExtractionTest.java
@@ -1,0 +1,30 @@
+package hellofx.fxheroes2.agg;
+
+import hellofx.fheroes2.agg.Agg;
+import hellofx.fheroes2.agg.Sprite;
+import hellofx.fheroes2.agg.icn.IcnKind;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+public class SpriteExtractionTest {
+    @Test
+    void testSpriteReading() {
+        Agg agg = Agg.Get();
+        agg.setup();
+
+        for (int i = 0; i < IcnKind.LASTICN; i++) {
+            int spritesPerIcon = agg.IcnSpriteCount(i);
+            for (int j = 0; j < spritesPerIcon; j++) {
+                Sprite sprite = agg.GetICN(i, j);
+
+                String fileName = String.format(
+                        "/tmp/h2/pic_%d_%d.png",
+                        i,
+                        j
+                );
+                sprite.saveToFile(new File(fileName));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This "PR" is actually a bug report. Some images aren't read correctly (I created two unit tests to illustrate the problem) and have their size incorrectly read. This causes the generated PNGs to be broken as well, even though the image information seems otherwise correct.